### PR TITLE
Use standard C pre-processor flags from environement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ndppd: ${OBJS}
 	${CXX} -o ndppd ${LDFLAGS} ${LIBS} ${OBJS}
 
 .cc.o:
-	${CXX} -c $(CXXFLAGS) -o $@ $<
+	${CXX} -c ${CPPFLAGS} $(CXXFLAGS) -o $@ $<
 
 clean:
 	rm -f ndppd ndppd.conf.5.gz ndppd.1.gz ${OBJS}


### PR DESCRIPTION
This allows build environment to set standard C pre-processor "CPPFLAGS".