### PR TITLE
Feature to automatically wire the routes for a gateway

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,9 +2,42 @@
 
     * Version 0.2.6
 
-        * Added a feature that will automatically create route entries
-          in the routing tables, thus providing an alternative to this
-          https://github.com/google/ndprbrd projects use-case.
+        * Added a new configuration setting named "deadtime" which allows
+          sessions that never made it the VALID to have a different (i.e.
+          shorter) life before they are removed (and potentially retried)
+          (defauilt is the same value as usual TTL for backwards compatibility)
+          
+        * Added a new configuration setting named "autowire" in the proxy
+          section (default is off)
+          
+        * If the "autowire" setting is on, then upon receiving a NDP
+          Neighbor Advertisment from one of the rule interfaces, a route will
+          be automatically added into the linux IP routing tables thus allowing
+          for a full featured gateway when IPv6 forwarding is turned on.
+          Note: Be careful as "accept_ra" may need to be set to 2 on the
+          interface during testing for the routing tables to retain their
+          default route (unrelated to this patch but took me a while to
+          discover).
+          
+        * When a session ends then anything that was "autowired" will be
+          automatically removed thus ensuring the routing tables are in a
+          similar state to before the daemon (or session) made any changes
+          
+        * Added a feature where the session will attempt to renew itself
+          (with a new NDP Solicitation) before it self-terminates, this is
+          required otherwise packets could be lost when the session terminates
+          triggering the automatically removal of the route table entry.
+          
+        * Ensured that renew operations only take place if the session has
+          been recently touched by an external solicitation - this ensures
+          that sessions that become IDLE are cleaned up quickly
+          
+        * Moved the daemonizing step till after the system executed the
+          configure step so that the error exit codes are returned to the daemon
+          caller.
+          
+        * No longer continuing to load the daemon if any of the interfaces fail
+          to load which should give a more predictable behaviour and better user experience.
 
 2016-04-18  Daniel Adolfsson  <daniel@priv.nu>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2017-01-07  Johnathan Sharratt <johnathan.sharratt@gmail.com>
+
+    * Version 0.2.6
+
+        * Added a feature that will automatically create route entries
+          in the routing tables, thus providing an alternative to this
+          https://github.com/google/ndprbrd projects use-case.
+
 2016-04-18  Daniel Adolfsson  <daniel@priv.nu>
 
     * Version 0.2.5

--- a/ndppd.conf-dist
+++ b/ndppd.conf-dist
@@ -91,6 +91,13 @@ proxy eth0 {
 
       auto
 
+      # autovia <yes|no|true|false>
+      # Any addresses updated using NDP advertisments will use a gateway to
+      # route traffic on this particular interface (only works wiith the iface
+      # rule type). Default is no
+
+      autovia no
+
       # Note that before version 0.2.2 of 'ndppd', if you didn't choose a
       # method, it defaulted to 'static'. For compatibility reasons we choose
       # to keep this behavior - for now (it may be removed in a future version).

--- a/ndppd.conf-dist
+++ b/ndppd.conf-dist
@@ -23,12 +23,12 @@ proxy eth0 {
 
    timeout 500   
 
-   # auto-wire <yes|no|true|false>
+   # autowire <yes|no|true|false>
    # Controls whether whether ndppd will automatically create host entries
    # in the routing tables when it receives Neighbor Advertisements on a
    # listening interface. The the default value is no.
 
-   auto-wire no
+   autowire no
    
    # ttl <integer>
    # Controls how long a valid or invalid entry remains in the cache, in 

--- a/ndppd.conf-dist
+++ b/ndppd.conf-dist
@@ -4,6 +4,12 @@
 
 route-ttl 30000
 
+# address-ttl <integer> (NEW)
+# This tells 'ndppd' how often to reload the IP address file /proc/net/if_inet6
+# Default value is '30000' (30 seconds).
+
+address-ttl 30000
+
 # proxy <interface>
 # This sets up a listener, that will listen for any Neighbor Solicitation
 # messages, and respond to them according to a set of rules (see below).

--- a/ndppd.conf-dist
+++ b/ndppd.conf-dist
@@ -24,11 +24,19 @@ proxy eth0 {
    timeout 500   
 
    # autowire <yes|no|true|false>
-   # Controls whether whether ndppd will automatically create host entries
+   # Controls whether ndppd will automatically create host entries
    # in the routing tables when it receives Neighbor Advertisements on a
    # listening interface. The the default value is no.
 
    autowire no
+
+   # promiscuous <yes|no|true|false>
+   # Controls whether ndppd will put the proxy listening interface into promiscuous
+   # mode and hence will react to inbound and outbound NDP commands. This is
+   # required for machines behind the gateway to talk to each other in more
+   # complex topology scenarios. The the default value is no.
+
+   promiscuous no
    
    # ttl <integer>
    # Controls how long a valid or invalid entry remains in the cache, in 

--- a/ndppd.conf-dist
+++ b/ndppd.conf-dist
@@ -38,6 +38,19 @@ proxy eth0 {
 
    autowire no
 
+   # keepalive <yes|no|true|false>
+   # Controls whether ndppd will automatically attempt to keep routing
+   # sessions alive by actively sending out NDP Solicitations before the the
+   # session is expired. The the default value is yes.
+   
+   keepalive yes
+
+   # retries <integer>
+   # Number of times a NDP Solicitation will be sent out before the daemon
+   # considers a route unreachable. The default value is 3
+
+   retries 3
+
    # promiscuous <yes|no|true|false>
    # Controls whether ndppd will put the proxy listening interface into promiscuous
    # mode and hence will react to inbound and outbound NDP commands. This is

--- a/ndppd.conf-dist
+++ b/ndppd.conf-dist
@@ -22,6 +22,13 @@ proxy eth0 {
    # invalidating the entry, in milliseconds. Default value is '500'.
 
    timeout 500   
+
+   # auto-wire <yes|no|true|false>
+   # Controls whether whether ndppd will automatically create host entries
+   # in the routing tables when it receives Neighbor Advertisements on a
+   # listening interface. The the default value is no.
+
+   auto-wire no
    
    # ttl <integer>
    # Controls how long a valid or invalid entry remains in the cache, in 

--- a/ndppd.conf-dist
+++ b/ndppd.conf-dist
@@ -33,6 +33,8 @@ proxy eth0 {
    # Controls whether ndppd will automatically create host entries
    # in the routing tables when it receives Neighbor Advertisements on a
    # listening interface. The the default value is no.
+   # Note: Autowire will ignore all rules with 'auto' or 'static' given it
+   # is expected that the routes are already defined for these paths
 
    autowire no
 

--- a/ndppd.conf.5
+++ b/ndppd.conf.5
@@ -48,7 +48,7 @@ Controls how long
 .B ndppd
 will cache an entry. This is in milliseconds, and the default value 
 is 30000 (30 seconds).
-.IP "auto-wire <yes|no>"
+.IP "autowire <yes|no>"
 Controls whether
 .B ndppd
 will automatically create host entries in the routing tables when

--- a/ndppd.conf.5
+++ b/ndppd.conf.5
@@ -54,6 +54,14 @@ Controls whether
 will automatically create host entries in the routing tables when
 .B ndppd receives Neighbor Advertisements on a listening interface.
 The default value is no.
+.IP "promiscuous <yes|no>"
+Controls whether
+.B ndppd
+will put the proxy listening interface into promiscuous mode and
+hence will react to inbound and outbound NDP commands. This is
+required for machines behind the gateway to talk to each other in
+more complex topology scenarios.
+The the default value is no.
 .IP "timeout <value>"
 Controls how long
 .B ndppd

--- a/ndppd.conf.5
+++ b/ndppd.conf.5
@@ -48,6 +48,12 @@ Controls how long
 .B ndppd
 will cache an entry. This is in milliseconds, and the default value 
 is 30000 (30 seconds).
+.IP "auto-wire <yes|no>"
+Controls whether
+.B ndppd
+will automatically create host entries in the routing tables when
+.B ndppd receives Neighbor Advertisements on a listening interface.
+The default value is no.
 .IP "timeout <value>"
 Controls how long
 .B ndppd

--- a/src/address.cc
+++ b/src/address.cc
@@ -132,6 +132,21 @@ bool address::operator!=(const address& addr) const
               ((_addr.s6_addr32[3] ^ addr._addr.s6_addr32[3]) & _mask.s6_addr32[3]));
 }
 
+bool address::is_empty() const
+{
+    if (_addr.s6_addr32[0] == 0 &&
+        _addr.s6_addr32[1] == 0 &&
+        _addr.s6_addr32[2] == 0 &&
+        _addr.s6_addr32[3] == 0 &&
+        _mask.s6_addr32[0] == 0xffffffff &&
+        _mask.s6_addr32[1] == 0xffffffff &&
+        _mask.s6_addr32[2] == 0xffffffff &&
+        _mask.s6_addr32[3] == 0xffffffff)
+        return true;
+        
+    return false;
+}
+
 void address::reset()
 {
     _addr.s6_addr32[0] = 0;
@@ -321,6 +336,10 @@ bool address::is_multicast() const
 
 bool address::is_unicast() const
 {
+    if (_addr.s6_addr32[2] == 0 &&
+        _addr.s6_addr32[3] == 0)
+        return false;
+    
     return _addr.s6_addr[0] != 0xff;
 }
 
@@ -360,7 +379,8 @@ void address::load(const std::string& path)
             ifs.getline(buf, sizeof(buf));
 
             if (ifs.gcount() < 53) {
-                logger::debug() << "skipping entry (size=" << ifs.gcount() << ")";
+                if (ifs.gcount() > 0)
+                    logger::debug() << "skipping entry (size=" << ifs.gcount() << ")";
                 continue;
             }
 

--- a/src/address.cc
+++ b/src/address.cc
@@ -57,6 +57,19 @@ address::address(const address& addr)
     _mask.s6_addr32[3] = addr._mask.s6_addr32[3];
 }
 
+address::address(const ptr<address>& addr)
+{
+    _addr.s6_addr32[0] = addr->_addr.s6_addr32[0];
+    _addr.s6_addr32[1] = addr->_addr.s6_addr32[1];
+    _addr.s6_addr32[2] = addr->_addr.s6_addr32[2];
+    _addr.s6_addr32[3] = addr->_addr.s6_addr32[3];
+
+    _mask.s6_addr32[0] = addr->_mask.s6_addr32[0];
+    _mask.s6_addr32[1] = addr->_mask.s6_addr32[1];
+    _mask.s6_addr32[2] = addr->_mask.s6_addr32[2];
+    _mask.s6_addr32[3] = addr->_mask.s6_addr32[3];
+}
+
 address::address(const std::string& str)
 {
     parse_string(str);

--- a/src/address.h
+++ b/src/address.h
@@ -56,6 +56,8 @@ public:
     bool operator!=(const address& addr) const;
 
     void reset();
+    
+    bool is_empty() const;
 
     const std::string to_string() const;
 

--- a/src/address.h
+++ b/src/address.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <string>
+#include <list>
 #include <netinet/ip6.h>
 
 #include "ndppd.h"
@@ -23,6 +24,8 @@
 NDPPD_NS_BEGIN
 
 class iface;
+
+class route;
 
 class address {
 public:
@@ -33,6 +36,12 @@ public:
     address(const in6_addr& addr);
     address(const in6_addr& addr, const in6_addr& mask);
     address(const in6_addr& addr, int prefix);
+    
+    static void update(int elapsed_time);
+
+    static int ttl();
+
+    static void ttl(int ttl);
 
     struct in6_addr& addr();
 
@@ -60,8 +69,20 @@ public:
     bool is_multicast() const;
 
     operator std::string() const;
+    
+    static std::list<ptr<route> > addresses();
+    
+    static void add(const address& addr, const std::string& ifname);
+    
+    static void load(const std::string& path);
 
 private:
+    static int _ttl;
+
+    static int _c_ttl;
+    
+    static std::list<ptr<route> > _addresses;
+    
     struct in6_addr _addr, _mask;
 };
 

--- a/src/address.h
+++ b/src/address.h
@@ -31,6 +31,7 @@ class address {
 public:
     address();
     address(const address& addr);
+    address(const ptr<address>& addr);
     address(const std::string& str);
     address(const char* str);
     address(const in6_addr& addr);

--- a/src/address.h
+++ b/src/address.h
@@ -70,11 +70,13 @@ public:
 
     operator std::string() const;
     
-    static std::list<ptr<route> > addresses();
-    
     static void add(const address& addr, const std::string& ifname);
     
     static void load(const std::string& path);
+    
+    static std::list<ptr<route> >::iterator addresses_begin();
+    
+    static std::list<ptr<route> >::iterator addresses_end();
 
 private:
     static int _ttl;

--- a/src/iface.cc
+++ b/src/iface.cc
@@ -589,7 +589,7 @@ int iface::poll_all()
                 const ptr<session> sess = *s_it;
 
                 if ((sess->taddr() == taddr) && (sess->status() == session::WAITING)) {
-                    sess->handle_advert();
+                    sess->handle_advert(ifa);
                     break;
                 }
             }

--- a/src/iface.cc
+++ b/src/iface.cc
@@ -66,7 +66,7 @@ iface::~iface()
             allmulti(_prev_allmulti);
         }
         if (_prev_promiscuous >= 0) {
-            allmulti(_prev_promiscuous);
+            promiscuous(_prev_promiscuous);
         }
         close(_pfd);
     }

--- a/src/iface.cc
+++ b/src/iface.cc
@@ -40,6 +40,7 @@
 #include <map>
 
 #include "ndppd.h"
+#include "route.h"
 
 NDPPD_NS_BEGIN
 
@@ -72,6 +73,9 @@ iface::~iface()
     }
 
     _map_dirty = true;
+    
+    _serves.clear();
+    _parents.clear();
 }
 
 ptr<iface> iface::open_pfd(const std::string& name, bool promiscuous)
@@ -297,7 +301,7 @@ ptr<iface> iface::open_ifd(const std::string& name)
     return ifa;
 }
 
-ssize_t iface::read(int fd, struct sockaddr* saddr, uint8_t* msg, size_t size)
+ssize_t iface::read(int fd, struct sockaddr* saddr, ssize_t saddr_size, uint8_t* msg, size_t size)
 {
     struct msghdr mhdr;
     struct iovec iov;
@@ -311,17 +315,17 @@ ssize_t iface::read(int fd, struct sockaddr* saddr, uint8_t* msg, size_t size)
 
     memset(&mhdr, 0, sizeof(mhdr));
     mhdr.msg_name = (caddr_t)saddr;
-    mhdr.msg_namelen = sizeof(struct sockaddr);
+    mhdr.msg_namelen = saddr_size;
     mhdr.msg_iov =& iov;
     mhdr.msg_iovlen = 1;
     
-    logger::debug() << "iface::read() ifa=" << name() << ", len=" << len;
-
     if ((len = recvmsg(fd,& mhdr, 0)) < 0)
     {
         logger::error() << "iface::read() failed! error=" << logger::err() << ", ifa=" << name();
         return -1;
     }
+    
+    logger::debug() << "iface::read() ifa=" << name() << ", len=" << len;
 
     if (len < sizeof(struct icmp6_hdr))
         return -1;
@@ -369,7 +373,7 @@ ssize_t iface::read_solicit(address& saddr, address& daddr, address& taddr)
     uint8_t msg[256];
     ssize_t len;
 
-    if ((len = read(_pfd, (struct sockaddr*)&t_saddr, msg, sizeof(msg))) < 0) {
+    if ((len = read(_pfd, (struct sockaddr*)&t_saddr, sizeof(struct sockaddr_ll), msg, sizeof(msg))) < 0) {
         logger::warning() << "iface::read_solicit() failed: " << logger::err();
         return -1;
     }
@@ -383,6 +387,11 @@ ssize_t iface::read_solicit(address& saddr, address& daddr, address& taddr)
     taddr = ns->nd_ns_target;
     daddr = ip6h->ip6_dst;
     saddr = ip6h->ip6_src;
+    
+    // Ignore packets sent from this machine
+    if (iface::is_local(saddr) == true) {
+        return 0;
+    }
 
     logger::debug() << "iface::read_solicit() saddr=" << saddr.to_string()
                     << ", daddr=" << daddr.to_string() << ", taddr=" << taddr.to_string() << ", len=" << len;
@@ -465,13 +474,22 @@ ssize_t iface::read_advert(address& saddr, address& taddr)
     struct sockaddr_in6 t_saddr;
     uint8_t msg[256];
     ssize_t len;
+    
+    memset(&t_saddr, 0, sizeof(struct sockaddr_in6));
+    t_saddr.sin6_family = AF_INET6;
+    t_saddr.sin6_port   = htons(IPPROTO_ICMPV6); // Needed?
 
-    if ((len = read(_ifd, (struct sockaddr* )&t_saddr, msg, sizeof(msg))) < 0) {
+    if ((len = read(_ifd, (struct sockaddr* )&t_saddr, sizeof(struct sockaddr_in6), msg, sizeof(msg))) < 0) {
         logger::warning() << "iface::read_advert() failed: " << logger::err();
         return -1;
     }
 
     saddr = t_saddr.sin6_addr;
+    
+    // Ignore packets sent from this machine
+    if (iface::is_local(saddr) == true) {
+        return 0;
+    }
 
     if (((struct icmp6_hdr* )msg)->icmp6_type != ND_NEIGHBOR_ADVERT)
         return -1;
@@ -481,6 +499,79 @@ ssize_t iface::read_advert(address& saddr, address& taddr)
     logger::debug() << "iface::read_advert() saddr=" << saddr.to_string() << ", taddr=" << taddr.to_string() << ", len=" << len;
 
     return len;
+}
+
+bool iface::is_local(const address& addr)
+{
+    // Check if the address is for an interface we own that is attached to
+    // one of the slave interfaces    
+    for (std::list<ptr<route> >::iterator ad = address::addresses_begin(); ad != address::addresses_end(); ad++)
+    {
+        if ((*ad)->addr() == addr)
+            return true;
+    }
+    return false;
+}
+
+bool iface::handle_local(const address& saddr, const address& taddr)
+{
+    // Check if the address is for an interface we own that is attached to
+    // one of the slave interfaces    
+    for (std::list<ptr<route> >::iterator ad = address::addresses_begin(); ad != address::addresses_end(); ad++)
+    {
+        if ((*ad)->addr() == taddr)
+        {
+            // Loop through all the serves that are using this iface to respond to NDP solicitation requests
+            for (std::list<weak_ptr<proxy> >::iterator pit = serves_begin(); pit != serves_end(); pit++) {
+                ptr<proxy> pr = (*pit);
+                if (!pr) continue;
+                
+                for (std::list<ptr<rule> >::iterator it = pr->rules_begin(); it != pr->rules_end(); it++) {
+                    ptr<rule> ru = *it;
+
+                    if (ru->daughter() && ru->daughter()->name() == (*ad)->ifname())
+                    {
+                        logger::debug() << "proxy::handle_solicit() found local taddr=" << taddr;
+                        write_advert(saddr, taddr, false);
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    
+    return false;
+}
+
+void iface::handle_reverse_advert(const address& saddr, const std::string& ifname)
+{
+    if (!saddr.is_unicast())
+        return;
+    
+    logger::debug()
+        << "proxy::handle_reverse_advert()";
+    
+    // Loop through all the parents that forward new NDP soliciation requests to this interface
+    for (std::list<weak_ptr<proxy> >::iterator pit = parents_begin(); pit != parents_end(); pit++) {
+        ptr<proxy> parent = (*pit);
+        if (!parent || !parent->ifa()) {
+            continue;
+        }
+    
+        // Setup the reverse path on any proxies that are dealing
+        // with the reverse direction (this helps improve connectivity and
+        // latency in a full duplex setup)
+        for (std::list<ptr<rule> >::iterator it = parent->rules_begin(); it != parent->rules_end(); it++) {
+            ptr<rule> ru = *it;
+
+            if (ru->addr() == saddr &&
+                ru->daughter()->name() == ifname)
+            {
+                logger::debug() << " - generating artifical advertisement: " << ifname;
+                parent->handle_stateless_advert(saddr, saddr, ifname, ru->autovia());
+            }
+        }
+    }
 }
 
 void iface::fixup_pollfds()
@@ -503,22 +594,6 @@ void iface::fixup_pollfds()
         _pollfds[i].revents = 0;
         i++;
     }
-}
-
-void iface::remove_session(const ptr<session>& se)
-{
-    for (std::list<weak_ptr<session> >::iterator it = _sessions.begin();
-            it != _sessions.end(); it++) {
-        if (*it == se) {
-            _sessions.erase(it);
-            break;
-        }
-    }
-}
-
-void iface::add_session(const ptr<session>& se)
-{
-    _sessions.push_back(se);
 }
 
 void iface::cleanup()
@@ -579,58 +654,95 @@ int iface::poll_all()
         ptr<iface> ifa = i_it->second;
 
         address saddr, daddr, taddr;
+        ssize_t size;
 
         if (is_pfd) {
-            if (ifa->read_solicit(saddr, daddr, taddr) < 0) {
+            size = ifa->read_solicit(saddr, daddr, taddr);
+            if (size < 0) {
                 logger::error() << "Failed to read from interface '%s'", ifa->_name.c_str();
                 continue;
-            }
-
-            if (!saddr.is_unicast()/* || !daddr.is_multicast()*/) {
+            } 
+            if (size == 0) {
+                logger::debug() << "iface::read_solicit() loopback received and ignored";
                 continue;
             }
             
-            if (ifa->_pr)
-            {
-                // Setup the reverse path
-                if (saddr.is_unicast()) {
-                    ptr<session> se = ifa->_pr->find_or_create_session(saddr);
-                    if (se) {
-                        se->add_iface(ifa);
-                        se->handle_advert(ifa);
-                    }
-                }
+            // Process any local addresses for interfaces that we are proxying
+            if (ifa->handle_local(saddr, taddr) == true) {
+                continue;
+            }
+            
+            // We have to handle all the parents who may be interested in
+            // the reverse path towards the one who sent this solicit.
+            // In fact, the parent need to know the source address in order
+            // to respond to NDP Solicitations
+            ifa->handle_reverse_advert(saddr, ifa->name());
 
-                // Now process the solicit
-                ifa->_pr->handle_solicit(saddr, taddr);
+            // Loop through all the proxies that are using this iface to respond to NDP solicitation requests
+            bool handled = false;
+            for (std::list<weak_ptr<proxy> >::iterator pit = ifa->serves_begin(); pit != ifa->serves_end(); pit++) {
+                ptr<proxy> pr = (*pit);
+                if (!pr) continue;
+                
+                // Process the solicitation request by relating it to other
+                // interfaces or lookup up any statics routes we have configured
+                handled = true;
+                pr->handle_solicit(saddr, taddr, ifa->name());
+            }
+            
+            // If it was not handled then write an error message
+            if (handled == false) {
+                logger::debug() << " - solicit was ignored";
             }
             
         } else {
-            if (ifa->read_advert(saddr, taddr) < 0) {
+            size = ifa->read_advert(saddr, taddr);
+            if (size < 0) {
                 logger::error() << "Failed to read from interface '%s'", ifa->_name.c_str();
                 continue;
             }
-
-            bool found = false;
-            for (std::list<weak_ptr<session> >::iterator s_it = ifa->_sessions.begin();
-                    s_it != ifa->_sessions.end(); s_it++) {
-                assert(!s_it->is_null());
-
-                const ptr<session> sess = *s_it;
-
-                if ((sess->taddr() == taddr)) {
-                    sess->handle_advert(ifa);
-                    found = true;
-                    break;
-                }
+            if (size == 0) {
+                logger::debug() << "iface::read_advert() loopback received and ignored";
+                continue;
             }
             
-            if (found == false) {
-                if (ifa->owner()) {
-                    ifa->owner()->handle_advert(taddr, ifa);
-                } else {
-                    logger::debug() << "iface::poll_all - ignoring advert on proxy iface=" << ifa->name();
+            // Process the NDP advert
+            bool handled = false;
+            for (std::list<weak_ptr<proxy> >::iterator pit = ifa->parents_begin(); pit != ifa->parents_end(); pit++) {
+                ptr<proxy> pr = (*pit);
+                if (!pr || !pr->ifa()) {
+                    continue;
                 }
+                
+                // The proxy must have a rule for this interface or it is not meant to receive
+                // any notifications and thus they must be ignored
+                bool autovia = false;
+                bool is_relevant = false;
+                for (std::list<ptr<rule> >::iterator it = pr->rules_begin(); it != pr->rules_end(); it++) {
+                    ptr<rule> ru = *it;
+                    
+                    if (ru->addr() == taddr &&
+                        ru->daughter() &&
+                        ru->daughter()->name() == ifa->name())
+                    {
+                        is_relevant = true;
+                        autovia = ru->autovia();
+                        break;
+                    }
+                }
+                if (is_relevant == false) {
+                    logger::debug() << "iface::read_advert() advert is not for " << ifa->name() << "...skipping";
+                    continue;
+                }
+                
+                // Process the NDP advertisement
+                handled = true;
+                pr->handle_advert(saddr, taddr, ifa->name(), autovia);
+            }
+            
+            // If it was not handled then write an error message
+            if (handled == false) {
+                logger::debug() << " - advert was ignored";
             }
         }
     }
@@ -721,24 +833,34 @@ const std::string& iface::name() const
     return _name;
 }
 
-void iface::pr(const ptr<proxy>& pr)
+void iface::add_serves(const ptr<proxy>& pr)
 {
-    _pr = pr;
+    _serves.push_back(pr);
 }
 
-const ptr<proxy>& iface::pr() const
+std::list<weak_ptr<proxy> >::iterator iface::serves_begin()
 {
-    return _pr;
+    return _serves.begin();
 }
 
-void iface::owner(const ptr<proxy>& pr)
+std::list<weak_ptr<proxy> >::iterator iface::serves_end()
 {
-    _owner = pr;
+    return _serves.end();
 }
 
-const ptr<proxy>& iface::owner() const
+void iface::add_parent(const ptr<proxy>& pr)
 {
-    return _owner;
+    _parents.push_back(pr);
+}
+
+std::list<weak_ptr<proxy> >::iterator iface::parents_begin()
+{
+    return _parents.begin();
+}
+
+std::list<weak_ptr<proxy> >::iterator iface::parents_end()
+{
+    return _parents.end();
 }
 
 NDPPD_NS_END

--- a/src/iface.cc
+++ b/src/iface.cc
@@ -599,6 +599,7 @@ int iface::poll_all()
                 continue;
             }
 
+            bool found = false;
             for (std::list<weak_ptr<session> >::iterator s_it = ifa->_sessions.begin();
                     s_it != ifa->_sessions.end(); s_it++) {
                 assert(!s_it->is_null());
@@ -607,7 +608,16 @@ int iface::poll_all()
 
                 if ((sess->taddr() == taddr) && (sess->status() == session::WAITING || sess->status() == session::RENEWING)) {
                     sess->handle_advert(ifa);
+                    found = true;
                     break;
+                }
+            }
+            
+            if (found == false) {
+                if (ifa->owner()) {
+                    ifa->owner()->handle_advert(saddr, taddr, ifa);
+                } else {
+                    logger::debug() << "iface::poll_all - ignoring advert on proxy iface=" << ifa->name();
                 }
             }
         }
@@ -707,6 +717,16 @@ void iface::pr(const ptr<proxy>& pr)
 const ptr<proxy>& iface::pr() const
 {
     return _pr;
+}
+
+void iface::owner(const ptr<proxy>& pr)
+{
+    _owner = pr;
+}
+
+const ptr<proxy>& iface::owner() const
+{
+    return _owner;
 }
 
 NDPPD_NS_END

--- a/src/iface.cc
+++ b/src/iface.cc
@@ -319,8 +319,7 @@ ssize_t iface::read(int fd, struct sockaddr* saddr, uint8_t* msg, size_t size)
 
     if ((len = recvmsg(fd,& mhdr, 0)) < 0)
     {
-        int e = errno;
-        logger::error() << "iface::read() failed! errno=" << e << ", ifa=" << name();
+        logger::error() << "iface::read() failed! error=" << logger::err() << ", ifa=" << name();
         return -1;
     }
 
@@ -357,8 +356,7 @@ ssize_t iface::write(int fd, const address& daddr, const uint8_t* msg, size_t si
 
     if ((len = sendmsg(fd,& mhdr, 0)) < 0)
     {
-        int e = errno;
-        logger::error() << "iface::write() failed! errno=" << e << ", ifa=" << name() << ", daddr=" << daddr.to_string();
+        logger::error() << "iface::write() failed! error=" << logger::err() << ", ifa=" << name() << ", daddr=" << daddr.to_string();
         return -1;
     }
 
@@ -371,8 +369,10 @@ ssize_t iface::read_solicit(address& saddr, address& daddr, address& taddr)
     uint8_t msg[256];
     ssize_t len;
 
-    if ((len = read(_pfd, (struct sockaddr*)&t_saddr, msg, sizeof(msg))) < 0)
+    if ((len = read(_pfd, (struct sockaddr*)&t_saddr, msg, sizeof(msg))) < 0) {
+        logger::warning() << "iface::read_solicit() failed: " << logger::err();
         return -1;
+    }
 
     struct ip6_hdr* ip6h =
           (struct ip6_hdr* )(msg + ETH_HLEN);
@@ -466,8 +466,10 @@ ssize_t iface::read_advert(address& saddr, address& taddr)
     uint8_t msg[256];
     ssize_t len;
 
-    if ((len = read(_ifd, (struct sockaddr* )&t_saddr, msg, sizeof(msg))) < 0)
+    if ((len = read(_ifd, (struct sockaddr* )&t_saddr, msg, sizeof(msg))) < 0) {
+        logger::warning() << "iface::read_advert() failed: " << logger::err();
         return -1;
+    }
 
     saddr = t_saddr.sin6_addr;
 
@@ -548,6 +550,7 @@ int iface::poll_all()
     int len;
 
     if ((len = ::poll(&_pollfds[0], _pollfds.size(), 50)) < 0) {
+        logger::error() << "Failed to poll interfaces: " << logger::err();
         return -1;
     }
 

--- a/src/iface.cc
+++ b/src/iface.cc
@@ -588,7 +588,7 @@ int iface::poll_all()
 
                 const ptr<session> sess = *s_it;
 
-                if ((sess->taddr() == taddr) && (sess->status() == session::WAITING)) {
+                if ((sess->taddr() == taddr) && (sess->status() == session::WAITING || sess->status() == session::RENEWING)) {
                     sess->handle_advert(ifa);
                     break;
                 }

--- a/src/iface.cc
+++ b/src/iface.cc
@@ -314,14 +314,18 @@ ssize_t iface::read(int fd, struct sockaddr* saddr, uint8_t* msg, size_t size)
     mhdr.msg_namelen = sizeof(struct sockaddr);
     mhdr.msg_iov =& iov;
     mhdr.msg_iovlen = 1;
+    
+    logger::debug() << "iface::read() ifa=" << name() << ", len=" << len;
 
     if ((len = recvmsg(fd,& mhdr, 0)) < 0)
+    {
+        int e = errno;
+        logger::error() << "iface::read() failed! errno=" << e << ", ifa=" << name();
         return -1;
+    }
 
     if (len < sizeof(struct icmp6_hdr))
         return -1;
-
-    logger::debug() << "iface::read() len=" << len;
 
     return len;
 }
@@ -346,7 +350,7 @@ ssize_t iface::write(int fd, const address& daddr, const uint8_t* msg, size_t si
     mhdr.msg_iov =& iov;
     mhdr.msg_iovlen = 1;
 
-    logger::debug() << "iface::write() daddr=" << daddr.to_string() << ", len="
+    logger::debug() << "iface::write() ifa=" << name() << ", daddr=" << daddr.to_string() << ", len="
                     << size;
 
     int len;
@@ -354,7 +358,7 @@ ssize_t iface::write(int fd, const address& daddr, const uint8_t* msg, size_t si
     if ((len = sendmsg(fd,& mhdr, 0)) < 0)
     {
         int e = errno;
-        logger::error() << "iface::write() failed! errno=" << e;
+        logger::error() << "iface::write() failed! errno=" << e << ", ifa=" << name() << ", daddr=" << daddr.to_string();
         return -1;
     }
 

--- a/src/iface.h
+++ b/src/iface.h
@@ -96,6 +96,9 @@ private:
 
     // Previous state of ALLMULTI for the interface.
     int _prev_allmulti;
+    
+    // Previous state of PROMISC for the interface
+    int _prev_promiscuous;
 
     // Name of this interface.
     std::string _name;
@@ -112,6 +115,10 @@ private:
     // Turns on/off ALLMULTI for this interface - returns the previous state
     // or -1 if there was an error.
     int allmulti(int state);
+    
+    // Turns on/off PROMISC for this interface - returns the previous state
+    // or -1 if there was an error
+    int promiscuous(int state);
 
     // Constructor.
     iface();

--- a/src/iface.h
+++ b/src/iface.h
@@ -42,9 +42,9 @@ public:
 
     static int poll_all();
 
-    static ssize_t read(int fd, struct sockaddr* saddr, uint8_t* msg, size_t size);
+    ssize_t read(int fd, struct sockaddr* saddr, uint8_t* msg, size_t size);
 
-    static ssize_t write(int fd, const address& daddr, const uint8_t* msg, size_t size);
+    ssize_t write(int fd, const address& daddr, const uint8_t* msg, size_t size);
 
     // Writes a NB_NEIGHBOR_SOLICIT message to the _ifd socket.
     ssize_t write_solicit(const address& taddr);

--- a/src/iface.h
+++ b/src/iface.h
@@ -42,7 +42,7 @@ public:
 
     static int poll_all();
 
-    ssize_t read(int fd, struct sockaddr* saddr, uint8_t* msg, size_t size);
+    ssize_t read(int fd, struct sockaddr* saddr, ssize_t saddr_size, uint8_t* msg, size_t size);
 
     ssize_t write(int fd, const address& daddr, const uint8_t* msg, size_t size);
 
@@ -57,25 +57,31 @@ public:
 
     // Reads a NB_NEIGHBOR_ADVERT message from the _ifd socket;
     ssize_t read_advert(address& saddr, address& taddr);
+    
+    bool handle_local(const address& saddr, const address& taddr);
+    
+    bool is_local(const address& addr);
+    
+    void handle_reverse_advert(const address& saddr, const std::string& ifname);
 
     // Returns the name of the interface.
     const std::string& name() const;
-
-    // Adds a session to be monitored for ND_NEIGHBOR_ADVERT messages.
-    void add_session(const ptr<session>& se);
-
-    void remove_session(const ptr<session>& se);
-
-    void pr(const ptr<proxy>& pr);
     
-    const ptr<proxy>& pr() const;
+    std::list<weak_ptr<proxy> >::iterator serves_begin();
     
-    void owner(const ptr<proxy>& pr);
+    std::list<weak_ptr<proxy> >::iterator serves_end();
     
-    const ptr<proxy>& owner() const;
+    void add_serves(const ptr<proxy>& proxy);
+    
+    std::list<weak_ptr<proxy> >::iterator parents_begin();
+    
+    std::list<weak_ptr<proxy> >::iterator parents_end();
+    
+    void add_parent(const ptr<proxy>& parent);
+    
+    static std::map<std::string, weak_ptr<iface> > _map;
 
 private:
-    static std::map<std::string, weak_ptr<iface> > _map;
 
     static bool _map_dirty;
 
@@ -106,14 +112,10 @@ private:
 
     // Name of this interface.
     std::string _name;
-
-    // An array of sessions that are monitoring this interface for
-    // ND_NEIGHBOR_ADVERT messages.
-    std::list<weak_ptr<session> > _sessions;
-
-    weak_ptr<proxy> _pr;
     
-    weak_ptr<proxy> _owner;
+    std::list<weak_ptr<proxy> > _serves;
+    
+    std::list<weak_ptr<proxy> > _parents;
 
     // The link-layer address of this interface.
     struct ether_addr hwaddr;

--- a/src/iface.h
+++ b/src/iface.h
@@ -67,8 +67,12 @@ public:
     void remove_session(const ptr<session>& se);
 
     void pr(const ptr<proxy>& pr);
-
+    
     const ptr<proxy>& pr() const;
+    
+    void owner(const ptr<proxy>& pr);
+    
+    const ptr<proxy>& owner() const;
 
 private:
     static std::map<std::string, weak_ptr<iface> > _map;
@@ -108,6 +112,8 @@ private:
     std::list<weak_ptr<session> > _sessions;
 
     weak_ptr<proxy> _pr;
+    
+    weak_ptr<proxy> _owner;
 
     // The link-layer address of this interface.
     struct ether_addr hwaddr;

--- a/src/iface.h
+++ b/src/iface.h
@@ -38,7 +38,7 @@ public:
 
     static ptr<iface> open_ifd(const std::string& name);
 
-    static ptr<iface> open_pfd(const std::string& name);
+    static ptr<iface> open_pfd(const std::string& name, bool promiscuous);
 
     static int poll_all();
 

--- a/src/ndppd.cc
+++ b/src/ndppd.cc
@@ -271,6 +271,9 @@ int main(int argc, char* argv[], char* env[])
     if (cf.is_null())
         return -1;
 
+    if (!configure(cf))
+        return -1;
+
     if (daemon) {
         logger::syslog(true);
 
@@ -279,9 +282,6 @@ int main(int argc, char* argv[], char* env[])
             return 1;
         }
     }
-
-    if (!configure(cf))
-        return -1;
 
     if (!pidfile.empty()) {
         std::ofstream pf;

--- a/src/ndppd.cc
+++ b/src/ndppd.cc
@@ -141,6 +141,11 @@ static bool configure(ptr<conf>& cf)
         route::ttl(30000);
     else
         route::ttl(*x_cf);
+    
+    if (!(x_cf = cf->find("address-ttl")))
+        address::ttl(30000);
+    else
+        address::ttl(*x_cf);
 
     std::vector<ptr<conf> >::const_iterator p_it;
 
@@ -334,6 +339,9 @@ int main(int argc, char* argv[], char* env[])
 
         if (rule::any_auto())
             route::update(elapsed_time);
+        
+        if (rule::any_iface())
+            address::update(elapsed_time);
 
         session::update_all(elapsed_time);
     }

--- a/src/ndppd.cc
+++ b/src/ndppd.cc
@@ -150,9 +150,8 @@ static bool configure(ptr<conf>& cf)
         }
 
         ptr<proxy> pr = proxy::open(*pr_cf);
-
-        if (!pr) {
-            return true;
+        if (!pr || pr.is_null() == true) {
+            return false;
         }
 
         if (!(x_cf = pr_cf->find("router")))
@@ -189,8 +188,14 @@ static bool configure(ptr<conf>& cf)
 
             address addr(*ru_cf);
 
-            if (x_cf = ru_cf->find("iface")) {
-                pr->add_rule(addr, iface::open_ifd(*x_cf));
+            if (x_cf = ru_cf->find("iface"))
+            {
+                ptr<iface> ifa = iface::open_ifd(*x_cf);
+                if (!ifa || ifa.is_null() == true) {
+                    return false;
+                }
+                
+                pr->add_rule(addr, ifa);
             } else if (ru_cf->find("auto")) {
                 pr->add_rule(addr, true);
             } else {

--- a/src/ndppd.cc
+++ b/src/ndppd.cc
@@ -36,9 +36,10 @@ using namespace ndppd;
 static int daemonize()
 {
     pid_t pid = fork();
-
-    if (pid < 0)
+    if (pid < 0) {
+        logger::error() << "Failed to fork during daemonize: " << logger::err();
         return -1;
+    }
 
     if (pid > 0)
         exit(0);
@@ -46,12 +47,15 @@ static int daemonize()
     umask(0);
 
     pid_t sid = setsid();
-
-    if (sid < 0)
+    if (sid < 0) {
+        logger::error() << "Failed to setsid during daemonize: " << logger::err();
         return -1;
+    }
 
-    if (chdir("/") < 0)
+    if (chdir("/") < 0) {
+        logger::error() << "Failed to change path during daemonize: " << logger::err();
         return -1;
+    }
 
     close(STDIN_FILENO);
     close(STDOUT_FILENO);
@@ -288,10 +292,8 @@ int main(int argc, char* argv[], char* env[])
     if (daemon) {
         logger::syslog(true);
 
-        if (daemonize() < 0) {
-            logger::error() << "Failed to daemonize process";
+        if (daemonize() < 0)
             return 1;
-        }
     }
 
     if (!pidfile.empty()) {

--- a/src/ndppd.cc
+++ b/src/ndppd.cc
@@ -169,6 +169,11 @@ static bool configure(ptr<conf>& cf)
             pr->ttl(30000);
         else
             pr->ttl(*x_cf);
+        
+        if (!(x_cf = pr_cf->find("deadtime")))
+            pr->deadtime(pr->ttl());
+        else
+            pr->deadtime(*x_cf);
 
         if (!(x_cf = pr_cf->find("timeout")))
             pr->timeout(500);

--- a/src/ndppd.cc
+++ b/src/ndppd.cc
@@ -159,6 +159,11 @@ static bool configure(ptr<conf>& cf)
             pr->router(true);
         else
             pr->router(*x_cf);
+        
+        if (!(x_cf = pr_cf->find("autowire")))
+            pr->autowire(false);
+        else
+            pr->autowire(*x_cf);
 
         if (!(x_cf = pr_cf->find("ttl")))
             pr->ttl(30000);

--- a/src/ndppd.cc
+++ b/src/ndppd.cc
@@ -204,6 +204,7 @@ static bool configure(ptr<conf>& cf)
                 if (!ifa || ifa.is_null() == true) {
                     return false;
                 }
+                ifa->owner(pr);
                 
                 pr->add_rule(addr, ifa);
             } else if (ru_cf->find("auto")) {

--- a/src/ndppd.cc
+++ b/src/ndppd.cc
@@ -148,8 +148,14 @@ static bool configure(ptr<conf>& cf)
         if (pr_cf->empty()) {
             return false;
         }
+        
+        bool promiscuous = false;
+        if (!(x_cf = pr_cf->find("promiscuous")))
+            promiscuous = false;
+        else
+            promiscuous = *x_cf;
 
-        ptr<proxy> pr = proxy::open(*pr_cf);
+        ptr<proxy> pr = proxy::open(*pr_cf, promiscuous);
         if (!pr || pr.is_null() == true) {
             return false;
         }

--- a/src/ndppd.cc
+++ b/src/ndppd.cc
@@ -178,6 +178,16 @@ static bool configure(ptr<conf>& cf)
             pr->autowire(false);
         else
             pr->autowire(*x_cf);
+        
+        if (!(x_cf = pr_cf->find("keepalive")))
+            pr->keepalive(true);
+        else
+            pr->keepalive(*x_cf);
+        
+        if (!(x_cf = pr_cf->find("retries")))
+            pr->retries(3);
+        else
+            pr->retries(*x_cf);
 
         if (!(x_cf = pr_cf->find("ttl")))
             pr->ttl(30000);

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -65,7 +65,8 @@ void proxy::handle_solicit(const address& saddr, const address& daddr,
     const address& taddr)
 {
     logger::debug()
-        << "proxy::handle_solicit() saddr=" << saddr.to_string()
+        << "proxy::handle_solicit() ifa=" << ((_ifa) ? _ifa->name() : "null")
+        << ", saddr=" << saddr.to_string()
         << ", taddr=" << taddr.to_string();
 
     // Let's check this proxy's list of sessions to see if we can

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -75,9 +75,10 @@ void proxy::handle_solicit(const address& saddr, const address& daddr,
     for (std::list<ptr<session> >::iterator sit = _sessions.begin();
             sit != _sessions.end(); sit++) {
         
-        (*sit)->touch();
-
-        if ((*sit)->taddr() == taddr) {
+        if ((*sit)->taddr() == taddr)
+        {
+            (*sit)->touch();
+            
             switch ((*sit)->status()) {
             case session::WAITING:
             case session::INVALID:

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -30,7 +30,7 @@ NDPPD_NS_BEGIN
 std::list<ptr<proxy> > proxy::_list;
 
 proxy::proxy() :
-    _router(true), _ttl(30000), _timeout(500)
+    _router(true), _ttl(30000), _timeout(500), _autowire(false)
 {
 }
 
@@ -104,7 +104,7 @@ void proxy::handle_solicit(const address& saddr, const address& daddr,
 
         if (ru->addr() == taddr) {
             if (!se) {
-                se = session::create(_ptr, saddr, daddr, taddr);
+                se = session::create(_ptr, saddr, daddr, taddr, _autowire);
             }
 
             if (ru->is_auto()) {
@@ -130,7 +130,7 @@ void proxy::handle_solicit(const address& saddr, const address& daddr,
                 if (if_addr_find((*it)->ifa()->name(), &taddr.const_addr())) {
                     logger::debug() << "Sending NA out " << (*it)->ifa()->name();
                     se->add_iface(_ifa);
-                    se->handle_advert();
+                    se->handle_advert(_ifa);
                 }
                 #endif
             }
@@ -175,6 +175,16 @@ bool proxy::router() const
 void proxy::router(bool val)
 {
     _router = val;
+}
+
+bool proxy::autowire() const
+{
+    return _autowire;
+}
+
+void proxy::autowire(bool val)
+{
+    _autowire = val;
 }
 
 int proxy::ttl() const

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -72,6 +72,8 @@ void proxy::handle_solicit(const address& saddr, const address& daddr,
 
     for (std::list<ptr<session> >::iterator sit = _sessions.begin();
             sit != _sessions.end(); sit++) {
+        
+        (*sit)->touch();
 
         if ((*sit)->taddr() == taddr) {
             switch ((*sit)->status()) {
@@ -80,6 +82,7 @@ void proxy::handle_solicit(const address& saddr, const address& daddr,
                 break;
 
             case session::VALID:
+            case session::RENEWING:
                 (*sit)->send_advert();
             }
 

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -30,7 +30,7 @@ NDPPD_NS_BEGIN
 std::list<ptr<proxy> > proxy::_list;
 
 proxy::proxy() :
-    _router(true), _ttl(30000), _timeout(500), _autowire(false)
+    _router(true), _ttl(30000), _deadtime(3000), _timeout(500), _autowire(false)
 {
 }
 
@@ -195,6 +195,16 @@ int proxy::ttl() const
 void proxy::ttl(int val)
 {
     _ttl = (val >= 0) ? val : 30000;
+}
+
+int proxy::deadtime() const
+{
+    return _deadtime;
+}
+
+void proxy::deadtime(int val)
+{
+    _deadtime = (val >= 0) ? val : 30000;
 }
 
 int proxy::timeout() const

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -32,7 +32,7 @@ static address all_nodes = address("ff02::1");
 std::list<ptr<proxy> > proxy::_list;
 
 proxy::proxy() :
-    _router(true), _ttl(30000), _deadtime(3000), _timeout(500), _autowire(false), _promiscuous(false)
+    _router(true), _ttl(30000), _deadtime(3000), _timeout(500), _autowire(false), _keepalive(true), _promiscuous(false), _retries(3)
 {
 }
 
@@ -86,7 +86,7 @@ ptr<session> proxy::find_or_create_session(const address& saddr, const address& 
         {
             if ((*ad)->addr() == taddr && (*ad)->ifname() == receiver->name())
             {
-                se = session::create(_ptr, saddr, daddr, taddr, _autowire);
+                se = session::create(_ptr, saddr, daddr, taddr, _autowire, _keepalive, _retries);
                 if (se) {
                     se->add_iface(receiver);
                     _sessions.push_back(se);
@@ -118,7 +118,7 @@ ptr<session> proxy::find_or_create_session(const address& saddr, const address& 
 
         if (ru->addr() == taddr) {
             if (!se) {
-                se = session::create(_ptr, saddr, daddr, taddr, _autowire);
+                se = session::create(_ptr, saddr, daddr, taddr, _autowire, _keepalive, _retries);
             }
             
             if (ru->is_auto()) {
@@ -256,6 +256,26 @@ bool proxy::autowire() const
 void proxy::autowire(bool val)
 {
     _autowire = val;
+}
+
+int proxy::retries() const
+{
+    return _retries;
+}
+
+void proxy::retries(int val)
+{
+    _retries = val;
+}
+
+bool proxy::keepalive() const
+{
+    return _keepalive;
+}
+
+void proxy::keepalive(bool val)
+{
+    _keepalive = val;
 }
 
 int proxy::ttl() const

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -30,15 +30,16 @@ NDPPD_NS_BEGIN
 std::list<ptr<proxy> > proxy::_list;
 
 proxy::proxy() :
-    _router(true), _ttl(30000), _deadtime(3000), _timeout(500), _autowire(false)
+    _router(true), _ttl(30000), _deadtime(3000), _timeout(500), _autowire(false), _promiscuous(false)
 {
 }
 
-ptr<proxy> proxy::create(const ptr<iface>& ifa)
+ptr<proxy> proxy::create(const ptr<iface>& ifa, bool promiscuous)
 {
     ptr<proxy> pr(new proxy());
     pr->_ptr = pr;
     pr->_ifa = ifa;
+    pr->_promiscuous = promiscuous;
 
     _list.push_back(pr);
 
@@ -49,15 +50,15 @@ ptr<proxy> proxy::create(const ptr<iface>& ifa)
     return pr;
 }
 
-ptr<proxy> proxy::open(const std::string& ifname)
+ptr<proxy> proxy::open(const std::string& ifname, bool promiscuous)
 {
-    ptr<iface> ifa = iface::open_pfd(ifname);
+    ptr<iface> ifa = iface::open_pfd(ifname, promiscuous);
 
     if (!ifa) {
         return ptr<proxy>();
     }
 
-    return create(ifa);
+    return create(ifa, promiscuous);
 }
 
 void proxy::handle_solicit(const address& saddr, const address& daddr,
@@ -168,6 +169,11 @@ void proxy::remove_session(const ptr<session>& se)
 const ptr<iface>& proxy::ifa() const
 {
     return _ifa;
+}
+
+bool proxy::promiscuous() const
+{
+    return _promiscuous;
 }
 
 bool proxy::router() const

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -34,11 +34,11 @@ public:
 
     static ptr<proxy> open(const std::string& ifn, bool promiscuous);
     
-    ptr<session> find_or_create_session(const address& saddr, const address& daddr, const address& taddr, const ptr<iface>& receiver);
+    ptr<session> find_or_create_session(const address& taddr);
     
-    void handle_advert(const address& saddr, const address& taddr, const ptr<iface>& receiver);
+    void handle_advert(const address& taddr, const ptr<iface>& receiver);
 
-    void handle_solicit(const address& saddr, const address& daddr, const address& taddr);
+    void handle_solicit(const address& saddr, const address& taddr);
 
     void remove_session(const ptr<session>& se);
 

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -30,9 +30,9 @@ class rule;
 
 class proxy {
 public:
-    static ptr<proxy> create(const ptr<iface>& ifa);
+    static ptr<proxy> create(const ptr<iface>& ifa, bool promiscuous);
 
-    static ptr<proxy> open(const std::string& ifn);
+    static ptr<proxy> open(const std::string& ifn, bool promiscuous);
 
     void handle_solicit(const address& saddr, const address& daddr,
         const address& taddr);
@@ -44,6 +44,8 @@ public:
     ptr<rule> add_rule(const address& addr, bool aut = false);
 
     const ptr<iface>& ifa() const;
+    
+    bool promiscuous() const;
 
     bool router() const;
 
@@ -75,6 +77,8 @@ private:
     std::list<ptr<rule> > _rules;
 
     std::list<ptr<session> > _sessions;
+    
+    bool _promiscuous;
 
     bool _router;
     

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -33,9 +33,12 @@ public:
     static ptr<proxy> create(const ptr<iface>& ifa, bool promiscuous);
 
     static ptr<proxy> open(const std::string& ifn, bool promiscuous);
+    
+    ptr<session> find_or_create_session(const address& saddr, const address& daddr, const address& taddr, const ptr<iface>& receiver);
+    
+    void handle_advert(const address& saddr, const address& taddr, const ptr<iface>& receiver);
 
-    void handle_solicit(const address& saddr, const address& daddr,
-        const address& taddr);
+    void handle_solicit(const address& saddr, const address& daddr, const address& taddr);
 
     void remove_session(const ptr<session>& se);
 

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -48,6 +48,10 @@ public:
     bool router() const;
 
     void router(bool val);
+    
+    bool autowire() const;
+
+    void autowire(bool val);
 
     int timeout() const;
 
@@ -69,6 +73,8 @@ private:
     std::list<ptr<session> > _sessions;
 
     bool _router;
+    
+    bool _autowire;
 
     int _ttl, _timeout;
 

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -29,22 +29,30 @@ class iface;
 class rule;
 
 class proxy {
-public:
+public:    
     static ptr<proxy> create(const ptr<iface>& ifa, bool promiscuous);
+    
+    static ptr<proxy> find_aunt(const std::string& ifname, const address& taddr);
 
     static ptr<proxy> open(const std::string& ifn, bool promiscuous);
     
     ptr<session> find_or_create_session(const address& taddr);
     
-    void handle_advert(const address& taddr, const ptr<iface>& receiver);
-
-    void handle_solicit(const address& saddr, const address& taddr);
+    void handle_advert(const address& saddr, const address& taddr, const std::string& ifname, bool use_via);
+    
+    void handle_stateless_advert(const address& saddr, const address& taddr, const std::string& ifname, bool use_via);
+    
+    void handle_solicit(const address& saddr, const address& taddr, const std::string& ifname);
 
     void remove_session(const ptr<session>& se);
 
-    ptr<rule> add_rule(const address& addr, const ptr<iface>& ifa);
+    ptr<rule> add_rule(const address& addr, const ptr<iface>& ifa, bool autovia);
 
     ptr<rule> add_rule(const address& addr, bool aut = false);
+    
+    std::list<ptr<rule> >::iterator rules_begin();
+    
+    std::list<ptr<rule> >::iterator rules_end();
 
     const ptr<iface>& ifa() const;
     

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -60,6 +60,10 @@ public:
     int ttl() const;
 
     void ttl(int val);
+    
+    int deadtime() const;
+
+    void deadtime(int val);
 
 private:
     static std::list<ptr<proxy> > _list;
@@ -76,7 +80,7 @@ private:
     
     bool _autowire;
 
-    int _ttl, _timeout;
+    int _ttl, _deadtime, _timeout;
 
     proxy();
 };

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -57,6 +57,14 @@ public:
     bool autowire() const;
 
     void autowire(bool val);
+    
+    int retries() const;
+
+    void retries(int val);
+    
+    bool keepalive() const;
+
+    void keepalive(bool val);
 
     int timeout() const;
 
@@ -86,6 +94,10 @@ private:
     bool _router;
     
     bool _autowire;
+    
+    int _retries;
+    
+    bool _keepalive;
 
     int _ttl, _deadtime, _timeout;
 

--- a/src/route.cc
+++ b/src/route.cc
@@ -105,19 +105,19 @@ void route::load(const std::string& path)
 
             unsigned char pfx;
 
-            if (hexdec(buf, (unsigned char* )&addr.addr(), 16) != 16) {
+            if (route::hexdec(buf, (unsigned char* )&addr.addr(), 16) != 16) {
                 // TODO: Warn here?
                 continue;
             }
 
-            if (hexdec(buf + 33,& pfx, 1) != 1) {
+            if (route::hexdec(buf + 33,& pfx, 1) != 1) {
                 // TODO: Warn here?
                 continue;
             }
 
             addr.prefix((int)pfx);
 
-            route::create(addr, token(buf + 141));
+            route::create(addr, route::token(buf + 141));
         }
     } catch (std::ifstream::failure e) {
         logger::warning() << "Failed to parse IPv6 routing data from '" << path << "'";

--- a/src/route.h
+++ b/src/route.h
@@ -44,6 +44,12 @@ public:
     const address& addr() const;
 
     ptr<iface> ifa();
+    
+    route(const address& addr, const std::string& ifname);
+
+    static size_t hexdec(const char* str, unsigned char* buf, size_t size);
+
+    static std::string token(const char* str);
 
 private:
     static int _ttl;
@@ -56,13 +62,7 @@ private:
 
     ptr<iface> _ifa;
 
-    static size_t hexdec(const char* str, unsigned char* buf, size_t size);
-
-    static std::string token(const char* str);
-
     static std::list<ptr<route> > _routes;
-
-    route(const address& addr, const std::string& ifname);
 
 };
 

--- a/src/rule.cc
+++ b/src/rule.cc
@@ -31,6 +31,8 @@ bool rule::_any_aut = false;
 
 bool rule::_any_iface = false;
 
+bool rule::_any_static = false;
+
 rule::rule()
 {
 }
@@ -40,7 +42,7 @@ ptr<rule> rule::create(const ptr<proxy>& pr, const address& addr, const ptr<ifac
     ptr<rule> ru(new rule());
     ru->_ptr  = ru;
     ru->_pr   = pr;
-    ru->_ifa  = ifa;
+    ru->_daughter  = ifa;
     ru->_addr = addr;
     ru->_aut  = false;
     _any_iface = true;
@@ -68,6 +70,9 @@ ptr<rule> rule::create(const ptr<proxy>& pr, const address& addr, bool aut)
     ru->_addr  = addr;
     ru->_aut   = aut;
     _any_aut   = _any_aut || aut;
+    
+    if (aut == false)
+        _any_static = true;
 
     logger::debug()
         << "rule::create() if=" << pr->ifa()->name().c_str() << ", addr=" << addr
@@ -81,14 +86,24 @@ const address& rule::addr() const
     return _addr;
 }
 
-ptr<iface> rule::ifa() const
+ptr<iface> rule::daughter() const
 {
-    return _ifa;
+    return _daughter;
 }
 
 bool rule::is_auto() const
 {
     return _aut;
+}
+
+bool rule::autovia() const
+{
+    return _autovia;
+}
+
+void rule::autovia(bool val)
+{
+    _autovia = val;
 }
 
 bool rule::any_auto()
@@ -99,6 +114,11 @@ bool rule::any_auto()
 bool rule::any_iface()
 {
     return _any_iface;
+}
+
+bool rule::any_static()
+{
+    return _any_static;
 }
 
 bool rule::check(const address& addr) const

--- a/src/rule.cc
+++ b/src/rule.cc
@@ -52,7 +52,7 @@ ptr<rule> rule::create(const ptr<proxy>& pr, const address& addr, const ptr<ifac
     if_add_to_list(ifindex, ifa);
 #endif
 
-    logger::debug() << "rule::create() if=" << pr->ifa()->name() << ", addr=" << addr;
+    logger::debug() << "rule::create() if=" << pr->ifa()->name() << ", slave=" << ifa->name() << ", addr=" << addr;
 
     return ru;
 }

--- a/src/rule.cc
+++ b/src/rule.cc
@@ -29,6 +29,8 @@ std::vector<interface> interfaces;
 
 bool rule::_any_aut = false;
 
+bool rule::_any_iface = false;
+
 rule::rule()
 {
 }
@@ -41,6 +43,7 @@ ptr<rule> rule::create(const ptr<proxy>& pr, const address& addr, const ptr<ifac
     ru->_ifa  = ifa;
     ru->_addr = addr;
     ru->_aut  = false;
+    _any_iface = true;
     unsigned int ifindex;
 
     ifindex = if_nametoindex(pr->ifa()->name().c_str());
@@ -91,6 +94,11 @@ bool rule::is_auto() const
 bool rule::any_auto()
 {
     return _any_aut;
+}
+
+bool rule::any_iface()
+{
+    return _any_iface;
 }
 
 bool rule::check(const address& addr) const

--- a/src/rule.h
+++ b/src/rule.h
@@ -44,6 +44,8 @@ public:
     bool check(const address& addr) const;
 
     static bool any_auto();
+    
+    static bool any_iface();
 
 private:
     weak_ptr<rule> _ptr;
@@ -57,6 +59,8 @@ private:
     bool _aut;
 
     static bool _any_aut;
+    
+    static bool _any_iface;
 
     rule();
 };

--- a/src/rule.h
+++ b/src/rule.h
@@ -37,7 +37,7 @@ public:
 
     const address& addr() const;
 
-    ptr<iface> ifa() const;
+    ptr<iface> daughter() const;
 
     bool is_auto() const;
 
@@ -45,14 +45,20 @@ public:
 
     static bool any_auto();
     
+    static bool any_static();
+    
     static bool any_iface();
+    
+    bool autovia() const;
+
+    void autovia(bool val);
 
 private:
     weak_ptr<rule> _ptr;
 
     weak_ptr<proxy> _pr;
 
-    ptr<iface> _ifa;
+    ptr<iface> _daughter;
 
     address _addr;
 
@@ -60,7 +66,11 @@ private:
 
     static bool _any_aut;
     
+    static bool _any_static;
+    
     static bool _any_iface;
+    
+    bool _autovia;
 
     rule();
 };

--- a/src/session.cc
+++ b/src/session.cc
@@ -81,7 +81,7 @@ ptr<session> session::create(const ptr<proxy>& pr, const address& saddr,
 
     logger::debug()
         << "session::create() pr=" << logger::format("%x", (proxy* )pr) << ", saddr=" << saddr
-        << ", daddr=" << daddr << ", taddr=" << taddr << " =" << logger::format("%x", (session* )se);
+        << ", daddr=" << daddr << ", taddr=" << taddr << ", autowire=" << (_autowire ? "yes" : "no") << " =" << logger::format("%x", (session* )se);
 
     return se;
 }

--- a/src/session.cc
+++ b/src/session.cc
@@ -130,6 +130,9 @@ void session::handle_advert(const ptr<iface>& ifa)
 
 void session::handle_advert()
 {
+    logger::debug()
+        << "session::handle_advert() taddr=" << _taddr << ", ttl=" << _pr->ttl();
+    
     _status = VALID;
     _ttl    = _pr->ttl();
 

--- a/src/session.cc
+++ b/src/session.cc
@@ -43,10 +43,16 @@ void session::update_all(int elapsed_time)
         }
 
         switch (se->_status) {
+            
         case session::WAITING:
             logger::debug() << "session is now invalid";
             se->_status = session::INVALID;
             se->_ttl    = se->_pr->deadtime();
+            break;
+            
+        case session::RENEWING:
+            logger::debug() << "session is became invalid";
+            se->_pr->remove_session(se);
             break;
             
         case session::VALID:            

--- a/src/session.cc
+++ b/src/session.cc
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <algorithm>
+#include <sstream>
 
 #include "ndppd.h"
 #include "proxy.h"
@@ -116,7 +117,18 @@ void session::handle_auto_wire(const ptr<iface>& ifa)
     logger::debug()
         << "session::handle_auto_wire() taddr=" << _taddr << ", ifa=" << ifa->name();
     
-    logger::debug() << "session::handle_auto_wire()";
+    std::stringstream route_cmd;
+    route_cmd << "ip";
+    route_cmd << " " << "-6";
+    route_cmd << " " << "replace";
+    route_cmd << " " << std::string(_taddr);
+    route_cmd << " " << "dev";
+    route_cmd << " " << ifa->name();
+            
+    logger::debug()
+        << "session::system(" << route_cmd.str() << ")";
+    
+    system(route_cmd.str().c_str());
 }
 
 void session::handle_advert(const ptr<iface>& ifa)

--- a/src/session.cc
+++ b/src/session.cc
@@ -45,7 +45,7 @@ void session::update_all(int elapsed_time)
         case session::WAITING:
             logger::debug() << "session is now invalid";
             se->_status = session::INVALID;
-            se->_ttl    = se->_pr->ttl();
+            se->_ttl    = se->_pr->deadtime();
             break;
 
         default:
@@ -81,7 +81,7 @@ ptr<session> session::create(const ptr<proxy>& pr, const address& saddr,
 
     logger::debug()
         << "session::create() pr=" << logger::format("%x", (proxy* )pr) << ", saddr=" << saddr
-        << ", daddr=" << daddr << ", taddr=" << taddr << ", autowire=" << (_autowire ? "yes" : "no") << " =" << logger::format("%x", (session* )se);
+        << ", daddr=" << daddr << ", taddr=" << taddr << ", autowire=" << (auto_wire == true ? "yes" : "no") << " =" << logger::format("%x", (session* )se);
 
     return se;
 }

--- a/src/session.cc
+++ b/src/session.cc
@@ -60,7 +60,12 @@ session::~session()
     logger::debug() << "session::~session() this=" << logger::format("%x", this);
 
     for (std::list<ptr<iface> >::iterator it = _ifaces.begin();
-            it != _ifaces.end(); it++) {
+            it != _ifaces.end(); it++)
+    {
+        if (_autowire == true) {
+            handle_auto_unwire((*it));
+        }
+                
         (*it)->remove_session(_ptr);
     }
 }
@@ -120,7 +125,28 @@ void session::handle_auto_wire(const ptr<iface>& ifa)
     std::stringstream route_cmd;
     route_cmd << "ip";
     route_cmd << " " << "-6";
+    route_cmd << " " << "route";
     route_cmd << " " << "replace";
+    route_cmd << " " << std::string(_taddr);
+    route_cmd << " " << "dev";
+    route_cmd << " " << ifa->name();
+            
+    logger::debug()
+        << "session::system(" << route_cmd.str() << ")";
+    
+    system(route_cmd.str().c_str());
+}
+
+void session::handle_auto_unwire(const ptr<iface>& ifa)
+{
+    logger::debug()
+        << "session::handle_auto_unwire() taddr=" << _taddr << ", ifa=" << ifa->name();
+    
+    std::stringstream route_cmd;
+    route_cmd << "ip";
+    route_cmd << " " << "-6";
+    route_cmd << " " << "route";
+    route_cmd << " " << "flush";
     route_cmd << " " << std::string(_taddr);
     route_cmd << " " << "dev";
     route_cmd << " " << ifa->name();

--- a/src/session.cc
+++ b/src/session.cc
@@ -45,19 +45,19 @@ void session::update_all(int elapsed_time)
         switch (se->_status) {
             
         case session::WAITING:
-            logger::debug() << "session is now invalid";
+            logger::debug() << "session is now invalid [taddr=" << se->_taddr << "]";
             se->_status = session::INVALID;
             se->_ttl    = se->_pr->deadtime();
             break;
             
         case session::RENEWING:
-            logger::debug() << "session is became invalid";
+            logger::debug() << "session is became invalid [taddr=" << se->_taddr << "]";
             se->_pr->remove_session(se);
             break;
             
         case session::VALID:            
             if (se->_touched == true) {
-                logger::debug() << "session is renewing";
+                logger::debug() << "session is renewing [taddr=" << se->_taddr << "]";
                 se->_status  = session::RENEWING;
                 se->_ttl     = se->_pr->timeout();
                 se->_touched = false;

--- a/src/session.cc
+++ b/src/session.cc
@@ -111,7 +111,7 @@ ptr<session> session::create(const ptr<proxy>& pr, const address& saddr,
     _sessions.push_back(se);
 
     logger::debug()
-        << "session::create() pr=" << logger::format("%x", (proxy* )pr) << ", saddr=" << saddr
+        << "session::create() pr=" << logger::format("%x", (proxy* )pr) << ", slave=" << ((pr->ifa()) ? pr->ifa()->name() : "null") << ", saddr=" << saddr
         << ", daddr=" << daddr << ", taddr=" << taddr << ", autowire=" << (auto_wire == true ? "yes" : "no") << " =" << logger::format("%x", (session* )se);
 
     return se;

--- a/src/session.h
+++ b/src/session.h
@@ -34,6 +34,8 @@ private:
     
     bool _autowire;
     
+    bool _wired;
+    
     bool _touched;
 
     // An array of interfaces this session is monitoring for
@@ -74,6 +76,8 @@ public:
     const address& saddr() const;
     
     bool autowire() const;
+    
+    bool wired() const;
     
     bool touched() const;
 

--- a/src/session.h
+++ b/src/session.h
@@ -43,6 +43,8 @@ private:
     // An array of interfaces this session is monitoring for
     // ND_NEIGHBOR_ADVERT on.
     std::list<ptr<iface> > _ifaces;
+    
+    std::list<ptr<address> > _pending;
 
     // The remaining time in miliseconds the object will stay in the
     // interface's session array or cache.
@@ -70,10 +72,11 @@ public:
     // Destructor.
     ~session();
 
-    static ptr<session> create(const ptr<proxy>& pr, const address& saddr,
-        const address& daddr, const address& taddr, bool autowire, bool keepalive, int retries);
+    static ptr<session> create(const ptr<proxy>& pr, const address& taddr, bool autowire, bool keepalive, int retries);
 
     void add_iface(const ptr<iface>& ifa);
+    
+    void add_pending(const address& addr);
 
     const address& taddr() const;
 
@@ -107,7 +110,7 @@ public:
     
     void touch();
 
-    void send_advert();
+    void send_advert(const address& daddr);
 
     void send_solicit();
 

--- a/src/session.h
+++ b/src/session.h
@@ -34,6 +34,8 @@ private:
     
     bool _autowire;
     
+    bool _keepalive;
+    
     bool _wired;
     
     bool _touched;
@@ -45,6 +47,10 @@ private:
     // The remaining time in miliseconds the object will stay in the
     // interface's session array or cache.
     int _ttl;
+    
+    int _fails;
+    
+    int _retries;
 
     int _status;
 
@@ -65,7 +71,7 @@ public:
     ~session();
 
     static ptr<session> create(const ptr<proxy>& pr, const address& saddr,
-        const address& daddr, const address& taddr, bool autowire);
+        const address& daddr, const address& taddr, bool autowire, bool keepalive, int retries);
 
     void add_iface(const ptr<iface>& ifa);
 
@@ -76,6 +82,12 @@ public:
     const address& saddr() const;
     
     bool autowire() const;
+    
+    int retries() const;
+    
+    int fails() const;
+
+    bool keepalive() const;
     
     bool wired() const;
     

--- a/src/session.h
+++ b/src/session.h
@@ -31,6 +31,8 @@ private:
     weak_ptr<proxy> _pr;
 
     address _saddr, _daddr, _taddr;
+    
+    bool _autowire;
 
     // An array of interfaces this session is monitoring for
     // ND_NEIGHBOR_ADVERT on.
@@ -58,7 +60,7 @@ public:
     ~session();
 
     static ptr<session> create(const ptr<proxy>& pr, const address& saddr,
-        const address& daddr, const address& taddr);
+        const address& daddr, const address& taddr, bool autowire);
 
     void add_iface(const ptr<iface>& ifa);
 
@@ -67,12 +69,18 @@ public:
     const address& daddr() const;
 
     const address& saddr() const;
+    
+    bool autowire() const;
 
     int status() const;
 
     void status(int val);
 
     void handle_advert();
+    
+    void handle_advert(const ptr<iface>& ifa);
+    
+    void handle_auto_wire(const ptr<iface>& ifa);
 
     void send_advert();
 

--- a/src/session.h
+++ b/src/session.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <vector>
+#include <string>
 
 #include "ndppd.h"
 
@@ -37,6 +38,8 @@ private:
     bool _keepalive;
     
     bool _wired;
+    
+    address _wired_via;
     
     bool _touched;
 
@@ -102,11 +105,11 @@ public:
     
     void handle_advert();
 
-    void handle_advert(const ptr<iface>& ifa);
+    void handle_advert(const address& saddr, const std::string& ifname, bool use_via);
     
-    void handle_auto_wire(const ptr<iface>& ifa);
+    void handle_auto_wire(const address& saddr, const std::string& ifname, bool use_via);
     
-    void handle_auto_unwire(const ptr<iface>& ifa);
+    void handle_auto_unwire(const std::string& ifname);
     
     void touch();
 

--- a/src/session.h
+++ b/src/session.h
@@ -81,6 +81,8 @@ public:
     void handle_advert(const ptr<iface>& ifa);
     
     void handle_auto_wire(const ptr<iface>& ifa);
+    
+    void handle_auto_unwire(const ptr<iface>& ifa);
 
     void send_advert();
 

--- a/src/session.h
+++ b/src/session.h
@@ -33,6 +33,8 @@ private:
     address _saddr, _daddr, _taddr;
     
     bool _autowire;
+    
+    bool _touched;
 
     // An array of interfaces this session is monitoring for
     // ND_NEIGHBOR_ADVERT on.
@@ -49,9 +51,10 @@ private:
 public:
     enum
     {
-        WAITING, // Waiting for an advert response.
-        VALID,   // Valid;
-        INVALID  // Invalid;
+        WAITING,  // Waiting for an advert response.
+        RENEWING, // Renewing;
+        VALID,    // Valid;
+        INVALID   // Invalid;
     };
 
     static void update_all(int elapsed_time);
@@ -71,6 +74,8 @@ public:
     const address& saddr() const;
     
     bool autowire() const;
+    
+    bool touched() const;
 
     int status() const;
 
@@ -83,6 +88,8 @@ public:
     void handle_auto_wire(const ptr<iface>& ifa);
     
     void handle_auto_unwire(const ptr<iface>& ifa);
+    
+    void touch();
 
     void send_advert();
 

--- a/src/session.h
+++ b/src/session.h
@@ -84,9 +84,9 @@ public:
     int status() const;
 
     void status(int val);
-
-    void handle_advert();
     
+    void handle_advert();
+
     void handle_advert(const ptr<iface>& ifa);
     
     void handle_auto_wire(const ptr<iface>& ifa);


### PR DESCRIPTION
As per this issue link referenced below from another overlapping project that uses this daemon at its core, the missing functionality has been re-implemented here so that its a cleaner and simpler solution for the use case (which itself is becomes increasingly common)
https://github.com/google/ndprbrd/issues/10

Summary of changes:
- Added a new configuration setting named "deadtime" which allows sessions that never made it the VALID to have a different (i.e. shorter) life before they are removed (and potentially retried) (defauilt is the same value as usual TTL for backwards compatibility)
- Added a new configuration setting named "autowire" in the proxy section (default is off)
- If the "autowire" setting is on, then upon receiving a NDP Neighbor Advertisment from one of the rule interfaces, a route will be automatically added into the linux IP routing tables thus allowing for a full featured gateway when IPv6 forwarding is turned on.
Note: Be careful as "accept_ra" may need to be set to 2 on the interface during testing for the routing tables to retain their default route (unrelated to this patch but took me a while to discover).
- When a session ends then anything that was "autowired" will be automatically removed thus ensuring the routing tables are in a similar state to before the daemon (or session) made any changes
- Added a feature where the session will attempt to renew itself (with a new NDP Solicitation) before it self-terminates, this is required otherwise packets could be lost when the session terminates triggering the automatically removal of the route table entry.
- Ensured that renew operations only take place if the session has been recently touched by an external solicitation - this ensures that sessions that become IDLE are cleaned up quickly
- Moved the daemonizing step till after the system executed the configure step so that the error exit codes are returned to the daemon caller.
- No longer continuing to load the daemon if any of the interfaces fail to load which should give a more predictable behaviour and better user experience.

All of this has been tested today in another project with some quite complex scenarios however it would be better if others contribute.

On another note, it may be a good idea in the future to put some limits on the number of sessions and use a hash table to lookup records to mitigate two fairly likely risks:
- That a DDOS attack could attempt to consume all the memory of a gateway
- That a legitimate but otherwise heavily utilized gateway may consume significant CPU if the number of sessions becomes large.

Note: I've not tested these potential risks thus in reality it may prove otherwise, perhaps time will tell

Kind Regards
John