### PR TITLE
remove cp nd-proxy from make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ install: all
 	chmod +x ${SBINDIR}/ndppd
 	cp ndppd.1.gz ${MANDIR}/man1
 	cp ndppd.conf.5.gz ${MANDIR}/man5
-	cp nd-proxy ${SBINDIR}
 
 ndppd.1.gz:
 	${GZIP} < ndppd.1 > ndppd.1.gz


### PR DESCRIPTION
nd-proxy is not built by `make all`, so it shouldn't be copied by `make install`.

Close #35.