### PR TITLE
Fake source IP address for advertisements

### DIFF
--- a/src/iface.h
+++ b/src/iface.h
@@ -44,7 +44,7 @@ public:
 
     ssize_t read(int fd, struct sockaddr* saddr, ssize_t saddr_size, uint8_t* msg, size_t size);
 
-    ssize_t write(int fd, const address& daddr, const uint8_t* msg, size_t size);
+    ssize_t write(int fd, const address* saddr, const address& daddr, const uint8_t* msg, size_t size);
 
     // Writes a NB_NEIGHBOR_SOLICIT message to the _ifd socket.
     ssize_t write_solicit(const address& taddr);

--- a/src/iface.h
+++ b/src/iface.h
@@ -104,6 +104,9 @@ private:
     // NB_NEIGHBOR_SOLICIT messages.
     int _pfd;
 
+    // Can we spoof source IP address when writing NB_NEIGHBOR_ADVERT?
+    bool _spoof;
+
     // Previous state of ALLMULTI for the interface.
     int _prev_allmulti;
     


### PR DESCRIPTION
Some OS are picky with the source IP address used when receiving
neighbor advertisements. For example, OpenBSD will drop such an
advertisement if the source address is not part of its local subnet.

When sending a neighbor advertisement, spoof the source IPv6 address
to match the target address. This requires a recent kernel (4.15+)
since the socket needs the `IPV6_FREEBIND` option to be set. We cannot
use `IP_FREEBIND` because the socket is of type `SOCK_RAW`.

An alternative would be to use a dedicated `SOCK_DGRAM` socket for
sending ICMP packets. Another option would be to make `setsockopt()`
non fatal and disable IP spoofing if we cannot set the option.

Fix #41