### PR TITLE
Fix issue #39, interface configuration

### DIFF
--- a/ndppd-init-debian-jessi
+++ b/ndppd-init-debian-jessi
@@ -1,0 +1,21 @@
+#!/bin/sh
+# kFreeBSD do not accept scripts as interpreters, using #!/bin/sh and sourcing.
+if [ true != "$INIT_D_SCRIPT_SOURCED" ] ; then
+    set "$0" "$@"; INIT_D_SCRIPT_SOURCED=true . /lib/init/init-d-script
+fi
+
+### BEGIN INIT INFO
+# Provides:          ndppd
+# Required-Start:    $remote_fs $syslog $network
+# Required-Stop:     $remote_fs $syslog $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: ndppd init script
+# Description:       NDP Proxy Daemon init script 
+### END INIT INFO
+# Author: Torben Nehmer <torben+ndppd@nehmer.net>
+
+DESC="NDP Proxy Daemon"
+PIDFILE=/run/ndppd.pid
+DAEMON=/usr/local/sbin/ndppd
+DAEMON_ARGS="-d -p $PIDFILE"

--- a/src/ndppd.cc
+++ b/src/ndppd.cc
@@ -351,15 +351,15 @@ int main(int argc, char* argv[], char* env[])
     if (cf.is_null())
         return -1;
 
-    if (!configure(cf))
-        return -1;
-
     if (daemon) {
         logger::syslog(true);
 
         if (daemonize() < 0)
             return 1;
     }
+
+    if (!configure(cf))
+        return -1;
 
     if (!pidfile.empty()) {
         std::ofstream pf;


### PR DESCRIPTION
Configure interfaces after daemonization, as otherwise we loose the ALLMULTI flag on the listening interfaces during the whole process. Probable cause is the parent restoring the original state of the interface flags before exitting.