### PR TITLE
Added SysV init script working on Debian Jessie. 

### DIFF
--- a/ndppd-init-debian-jessie
+++ b/ndppd-init-debian-jessie
@@ -1,0 +1,24 @@
+#!/bin/sh
+# kFreeBSD do not accept scripts as interpreters, using #!/bin/sh and sourcing.
+if [ true != "$INIT_D_SCRIPT_SOURCED" ] ; then
+    set "$0" "$@"; INIT_D_SCRIPT_SOURCED=true . /lib/init/init-d-script
+fi
+
+### BEGIN INIT INFO
+# Provides:          ndppd
+# Required-Start:    $remote_fs $syslog $network
+# Required-Stop:     $remote_fs $syslog $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: ndppd init script
+# Description:       NDP Proxy Daemon init script 
+#                    Build on Debian Jessie, but should work on current stable as 
+#                    well. Copy to /etc/init.d/ndppd and make it executable.
+### END INIT INFO
+
+# Author: Torben Nehmer
+
+DESC="NDP Proxy Daemon"
+PIDFILE=/run/ndppd.pid
+DAEMON=/usr/local/sbin/ndppd
+DAEMON_ARGS="-d -p $PIDFILE"


### PR DESCRIPTION
Should work on other Debians as well.
Just copy the init script to /etc/init.d/ndppd and make it executable.