### PR TITLE
Add the ability to set a target hardware address for advertisements

### DIFF
--- a/src/iface.cc
+++ b/src/iface.cc
@@ -439,7 +439,7 @@ ssize_t iface::write_solicit(const address& taddr)
                  + sizeof(struct nd_opt_hdr) + 6);
 }
 
-ssize_t iface::write_advert(const address& daddr, const address& taddr, bool router)
+ssize_t iface::write_advert(const address& daddr, const address& taddr, bool router, const struct ether_addr* target_hwaddr)
 {
     char buf[128];
 
@@ -459,11 +459,16 @@ ssize_t iface::write_advert(const address& daddr, const address& taddr, bool rou
 
     memcpy(&na->nd_na_target,& taddr.const_addr(), sizeof(struct in6_addr));
 
+    if (!target_hwaddr) {
+        target_hwaddr = &hwaddr;
+    }
+
     memcpy(buf + sizeof(struct nd_neighbor_advert) + sizeof(struct nd_opt_hdr),
-           &hwaddr, 6);
+           target_hwaddr, 6);
 
     logger::debug() << "iface::write_advert() daddr=" << daddr.to_string()
-                    << ", taddr=" << taddr.to_string();
+                    << ", taddr=" << taddr.to_string()
+                    << ", hwaddr=" << ether_ntoa(target_hwaddr);
 
     return write(_ifd, daddr, (uint8_t* )buf, sizeof(struct nd_neighbor_advert) +
         sizeof(struct nd_opt_hdr) + 6);

--- a/src/iface.h
+++ b/src/iface.h
@@ -50,7 +50,7 @@ public:
     ssize_t write_solicit(const address& taddr);
 
     // Writes a NB_NEIGHBOR_ADVERT message to the _ifd socket;
-    ssize_t write_advert(const address& daddr, const address& taddr, bool router);
+    ssize_t write_advert(const address& daddr, const address& taddr, bool router, const struct ether_addr* target_hwaddr = NULL);
 
     // Reads a NB_NEIGHBOR_SOLICIT message from the _pfd socket.
     ssize_t read_solicit(address& saddr, address& daddr, address& taddr);

--- a/src/ndppd.cc
+++ b/src/ndppd.cc
@@ -26,6 +26,7 @@
 
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <netinet/ether.h>
 #include <unistd.h>
 
 #include "ndppd.h"
@@ -205,6 +206,16 @@ static bool configure(ptr<conf>& cf)
             pr->timeout(500);
         else
             pr->timeout(*x_cf);
+
+        if (x_cf = pr_cf->find("target_hwaddr")) {
+            std::string addr_str = *x_cf;
+            struct ether_addr* addr = ether_aton(addr_str.c_str());
+            if (!addr) {
+                logger::error() << "Specified target_hwaddr is invalid";
+                return false;
+            }
+            pr->target_hwaddr(addr);
+        }
 
         std::vector<ptr<conf> >::const_iterator r_it;
 

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -34,6 +34,7 @@ std::list<ptr<proxy> > proxy::_list;
 proxy::proxy() :
     _router(true), _ttl(30000), _deadtime(3000), _timeout(500), _autowire(false), _keepalive(true), _promiscuous(false), _retries(3)
 {
+    memset(&_target_hwaddr, 0, sizeof(struct ether_addr));
 }
 
 ptr<proxy> proxy::find_aunt(const std::string& ifname, const address& taddr)
@@ -315,6 +316,22 @@ int proxy::deadtime() const
 void proxy::deadtime(int val)
 {
     _deadtime = (val >= 0) ? val : 30000;
+}
+
+const struct ether_addr* proxy::target_hwaddr() const
+{
+    struct ether_addr blank = {{0}};
+    if (memcmp(&blank, &_target_hwaddr, sizeof(struct ether_addr)) == 0) {
+        return NULL;
+    }
+    else {
+        return &_target_hwaddr;
+    }
+}
+
+void proxy::target_hwaddr(const struct ether_addr* val)
+{
+    memcpy(&_target_hwaddr, val, sizeof(struct ether_addr));
 }
 
 int proxy::timeout() const

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -20,6 +20,7 @@
 #include <map>
 
 #include <sys/poll.h>
+#include <net/ethernet.h>
 
 #include "ndppd.h"
 
@@ -86,6 +87,10 @@ public:
 
     void deadtime(int val);
 
+    const struct ether_addr* target_hwaddr() const;
+
+    void target_hwaddr(const struct ether_addr* val);
+
 private:
     static std::list<ptr<proxy> > _list;
 
@@ -96,11 +101,11 @@ private:
     std::list<ptr<rule> > _rules;
 
     std::list<ptr<session> > _sessions;
-    
+
     bool _promiscuous;
 
     bool _router;
-    
+
     bool _autowire;
     
     int _retries;
@@ -108,6 +113,8 @@ private:
     bool _keepalive;
 
     int _ttl, _deadtime, _timeout;
+
+    struct ether_addr _target_hwaddr;
 
     proxy();
 };

--- a/src/session.cc
+++ b/src/session.cc
@@ -181,7 +181,7 @@ void session::touch()
 
 void session::send_advert(const address& daddr)
 {
-    _pr->ifa()->write_advert(daddr, _taddr, _pr->router());
+    _pr->ifa()->write_advert(daddr, _taddr, _pr->router(), _pr->target_hwaddr());
 }
 
 void session::handle_auto_wire(const address& saddr, const std::string& ifname, bool use_via)


### PR DESCRIPTION
Useful when the proxy is responding on behalf of another router.