### PR TITLE
bump version to 0.2.5

### DIFF
--- a/src/ndppd.h
+++ b/src/ndppd.h
@@ -21,7 +21,7 @@
 #define NDPPD_NS_BEGIN   namespace ndppd {
 #define NDPPD_NS_END     }
 
-#define NDPPD_VERSION   "0.2.4"
+#define NDPPD_VERSION   "0.2.5"
 
 #include <assert.h>
 


### PR DESCRIPTION
otherwise running `ndppd` gives `(notice) ndppd (NDP Proxy Daemon) version 0.2.4` :D