### PR TITLE
fix warning and crash

### DIFF
--- a/src/iface.cc
+++ b/src/iface.cc
@@ -564,7 +564,7 @@ void iface::handle_reverse_advert(const address& saddr, const std::string& ifnam
         for (std::list<ptr<rule> >::iterator it = parent->rules_begin(); it != parent->rules_end(); it++) {
             ptr<rule> ru = *it;
 
-            if (ru->addr() == saddr &&
+            if (ru->addr() == saddr && ru->daughter() &&
                 ru->daughter()->name() == ifname)
             {
                 logger::debug() << " - generating artifical advertisement: " << ifname;
@@ -664,7 +664,7 @@ int iface::poll_all()
         if (is_pfd) {
             size = ifa->read_solicit(saddr, daddr, taddr);
             if (size < 0) {
-                logger::error() << "Failed to read from interface '%s'", ifa->_name.c_str();
+                logger::error() << "Failed to read from interface '" << ifa->_name.c_str() << "'";
                 continue;
             } 
             if (size == 0) {
@@ -703,7 +703,7 @@ int iface::poll_all()
         } else {
             size = ifa->read_advert(saddr, taddr);
             if (size < 0) {
-                logger::error() << "Failed to read from interface '%s'", ifa->_name.c_str();
+                logger::error() << "Failed to read from interface '" << ifa->_name.c_str() << "'";
                 continue;
             }
             if (size == 0) {

--- a/src/session.cc
+++ b/src/session.cc
@@ -209,7 +209,11 @@ void session::handle_auto_wire(const address& saddr, const std::string& ifname, 
         logger::debug()
             << "session::system(" << route_cmd.str() << ")";
         
-        system(route_cmd.str().c_str());
+        int ret = system(route_cmd.str().c_str());
+        if (ret != 0) {
+           logger::error()
+                << "system(" << route_cmd.str().c_str() << ") failed, return " << ret;
+        }
         
         _wired_via = saddr;
     }
@@ -233,7 +237,11 @@ void session::handle_auto_wire(const address& saddr, const std::string& ifname, 
         logger::debug()
             << "session::system(" << route_cmd.str() << ")";
 
-        system(route_cmd.str().c_str());
+        int ret = system(route_cmd.str().c_str());
+        if (ret != 0) {
+            logger::error()
+                << "system(" << route_cmd.str().c_str() << ") failed, return " << ret;
+        }
     }
     
     _wired = true;
@@ -261,7 +269,11 @@ void session::handle_auto_unwire(const std::string& ifname)
         logger::debug()
             << "session::system(" << route_cmd.str() << ")";
 
-        system(route_cmd.str().c_str());
+        int ret = system(route_cmd.str().c_str());
+        if (ret != 0) {
+            logger::error()
+                << "system(" << route_cmd.str().c_str() << ") failed, return " << ret;
+        }
     }
     
     if (_wired_via.is_empty() == false) {
@@ -277,7 +289,11 @@ void session::handle_auto_unwire(const std::string& ifname)
         logger::debug()
             << "session::system(" << route_cmd.str() << ")";
 
-        system(route_cmd.str().c_str());
+        int ret = system(route_cmd.str().c_str());
+        if (ret != 0) {
+            logger::error()
+                << "system(" << route_cmd.str().c_str() << ") failed, return " << ret;
+        }
     }
     
     _wired = false;


### PR DESCRIPTION
### Warning

> build on ubuntu 24.04(x64) Server.

```bash
src/iface.cc: In static member function ‘static int ndppd::iface::poll_all()’:
src/iface.cc:667:90: warning: ignoring return value of ‘const _CharT* std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::c_str() const [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’, declared with attribute ‘nodiscard’ [-Wunused-result]
  667 |                 logger::error() << "Failed to read from interface '%s'", ifa->_name.c_str();
      |                                                                          ~~~~~~~~~~~~~~~~^~
In file included from /usr/include/c++/13/string:54,
                 from src/iface.cc:38:
/usr/include/c++/13/bits/basic_string.h:2595:7: note: declared here
 2595 |       c_str() const _GLIBCXX_NOEXCEPT
      |       ^~~~~
src/iface.cc:706:90: warning: ignoring return value of ‘const _CharT* std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::c_str() const [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’, declared with attribute ‘nodiscard’ [-Wunused-result]
  706 |                 logger::error() << "Failed to read from interface '%s'", ifa->_name.c_str();
      |                                                                          ~~~~~~~~~~~~~~~~^~
/usr/include/c++/13/bits/basic_string.h:2595:7: note: declared here
 2595 |       c_str() const _GLIBCXX_NOEXCEPT
      |       ^~~~~
g++ -c  -O3 -o src/proxy.o src/proxy.cc
g++ -c  -O3 -o src/address.o src/address.cc
g++ -c  -O3 -o src/rule.o src/rule.cc
g++ -c  -O3 -o src/session.o src/session.cc
src/session.cc: In member function ‘void ndppd::session::handle_auto_wire(const ndppd::address&, const std::string&, bool)’:
src/session.cc:212:15: warning: ignoring return value of ‘int system(const char*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  212 |         system(route_cmd.str().c_str());
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
src/session.cc:236:15: warning: ignoring return value of ‘int system(const char*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  236 |         system(route_cmd.str().c_str());
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
src/session.cc: In member function ‘void ndppd::session::handle_auto_unwire(const std::string&)’:
src/session.cc:264:15: warning: ignoring return value of ‘int system(const char*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  264 |         system(route_cmd.str().c_str());
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
src/session.cc:280:15: warning: ignoring return value of ‘int system(const char*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  280 |         system(route_cmd.str().c_str());
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
```

### Error

When rule is static，`ru->daughter()`  may be nullptr.

https://github.com/DanielAdolfsson/ndppd/blob/4f0301f94345c92b723392ed2d73f04f910e6c30/src/iface.cc#L568

