### PR TITLE
send NA using raw ETH_P_IPV6 packet API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PKG_CONFIG ?= pkg-config
 
 
 OBJS     = src/logger.o src/ndppd.o src/iface.o src/proxy.o src/address.o \
-           src/rule.o src/session.o src/conf.o src/route.o 
+           src/rule.o src/session.o src/solicitor.o src/conf.o src/route.o src/cksum.o
 
 ifdef WITH_ND_NETLINK
   LIBS     = `${PKG_CONFIG} --libs glib-2.0 libnl-3.0 libnl-route-3.0` -pthread

--- a/src/address.h
+++ b/src/address.h
@@ -50,9 +50,9 @@ public:
 
     struct in6_addr& mask();
 
-    // Compare _a/_m against a._a.
+    /// Compare _a/_m against a._a. NON-PERMUTATIVE!
     bool operator==(const address& addr) const;
-
+    /// NON-PERMUTATIVE!
     bool operator!=(const address& addr) const;
 
     void reset();

--- a/src/cksum.cc
+++ b/src/cksum.cc
@@ -1,0 +1,47 @@
+// ndppd - NDP Proxy Daemon
+// Copyright (C) 2011  Daniel Adolfsson <daniel@priv.nu>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// file author: Sergey E. Kolesnikov <rockingdemon@gmail.com>
+#include <cstdint>
+#include <netinet/ip6.h>
+#include "cksum.h"
+
+NDPPD_NS_BEGIN
+
+uint_fast32_t partial_sum(const void* data, int size)
+{
+    const uint16_t* wend= (const uint16_t*) data + size / 2;
+    uint_fast32_t accum = 0;
+    for (const uint16_t* wdata=(const uint16_t*) data; wdata < wend; wdata++) {
+        accum += *wdata;
+    }
+    if (size & 1) {
+        accum += *((const uint8_t*) data + size - 1);
+    }
+    return accum;
+}
+
+uint16_t icmp6_sum(const ip6_hdr* hdr, const void* payload, int size)
+{
+    uint_fast32_t accum = partial_sum(payload, size);
+    accum += partial_sum(&hdr->ip6_src, sizeof(struct in6_addr));
+    accum += partial_sum(&hdr->ip6_dst, sizeof(struct in6_addr));
+    accum += hdr->ip6_plen;
+    accum += htons(hdr->ip6_nxt); // calculated as 16-bit network order word
+    return ~((accum >> 16) + (accum & 0xffff));
+}
+
+NDPPD_NS_END

--- a/src/cksum.h
+++ b/src/cksum.h
@@ -1,0 +1,27 @@
+// ndppd - NDP Proxy Daemon
+// Copyright (C) 2011  Daniel Adolfsson <daniel@priv.nu>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// file author: Sergey E. Kolesnikov <rockingdemon@gmail.com>
+#pragma once
+#include <netinet/ip6.h>
+#include <netinet/icmp6.h>
+#include "ndppd.h"
+
+NDPPD_NS_BEGIN
+
+uint16_t icmp6_sum(const struct ip6_hdr* hdr, const void* payload, int size);
+
+NDPPD_NS_END

--- a/src/iface.h
+++ b/src/iface.h
@@ -50,15 +50,15 @@ public:
     ssize_t write_solicit(const address& taddr);
 
     // Writes a NB_NEIGHBOR_ADVERT message to the _ifd socket;
-    ssize_t write_advert(const address& daddr, const address& taddr, bool router);
+    ssize_t write_advert(const ether_addr& dhwaddr, const address& daddr, const address& taddr, bool router);
 
     // Reads a NB_NEIGHBOR_SOLICIT message from the _pfd socket.
-    ssize_t read_solicit(address& saddr, address& daddr, address& taddr);
+    ssize_t read_solicit(ether_addr& shwaddr, address& saddr, address& daddr, address& taddr);
 
     // Reads a NB_NEIGHBOR_ADVERT message from the _ifd socket;
     ssize_t read_advert(address& saddr, address& taddr);
-    
-    bool handle_local(const address& saddr, const address& taddr);
+
+    bool handle_local(const ether_addr& shwaddr, const address& saddr, const address& taddr);
     
     bool is_local(const address& addr);
     

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -187,7 +187,7 @@ void proxy::handle_stateless_advert(const address& saddr, const address& taddr, 
     }
 }
 
-void proxy::handle_solicit(const address& saddr, const address& taddr, const std::string& ifname)
+void proxy::handle_solicit(const ether_addr& shwaddr, const address& saddr, const address& taddr, const std::string& ifname)
 {
     logger::debug()
         << "proxy::handle_solicit()";
@@ -206,12 +206,12 @@ void proxy::handle_solicit(const address& saddr, const address& taddr, const std
         switch (se->status()) {
             case session::WAITING:
             case session::INVALID:
-                se->add_pending(saddr);
+                se->add_pending(shwaddr, saddr);
                 break;
 
             case session::VALID:
             case session::RENEWING:
-                se->send_advert(saddr);
+                se->send_advert(shwaddr, saddr);
                 break;
         }
      }

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -41,8 +41,8 @@ public:
     void handle_advert(const address& saddr, const address& taddr, const std::string& ifname, bool use_via);
     
     void handle_stateless_advert(const address& saddr, const address& taddr, const std::string& ifname, bool use_via);
-    
-    void handle_solicit(const address& saddr, const address& taddr, const std::string& ifname);
+
+    void handle_solicit(const ether_addr& shwaddr, const address& saddr, const address& taddr, const std::string& ifname);
 
     void remove_session(const ptr<session>& se);
 

--- a/src/session.h
+++ b/src/session.h
@@ -19,6 +19,7 @@
 #include <string>
 
 #include "ndppd.h"
+#include "solicitor.h"
 
 NDPPD_NS_BEGIN
 
@@ -46,8 +47,9 @@ private:
     // An array of interfaces this session is monitoring for
     // ND_NEIGHBOR_ADVERT on.
     std::list<ptr<iface> > _ifaces;
-    
-    std::list<ptr<address> > _pending;
+
+    /// pending solicitors
+    std::list<ptr<solicitor>> _pending;
 
     // The remaining time in miliseconds the object will stay in the
     // interface's session array or cache.
@@ -79,7 +81,7 @@ public:
 
     void add_iface(const ptr<iface>& ifa);
     
-    void add_pending(const address& addr);
+    void add_pending(const ether_addr& hwaddr, const address& addr);
 
     const address& taddr() const;
 
@@ -102,7 +104,8 @@ public:
     int status() const;
 
     void status(int val);
-    
+
+    /// handle incoming advert
     void handle_advert();
 
     void handle_advert(const address& saddr, const std::string& ifname, bool use_via);
@@ -113,7 +116,9 @@ public:
     
     void touch();
 
-    void send_advert(const address& daddr);
+    /// send advert to original solicitation
+    /// \param daddr - IPv6 dhwaddr of router requesting original solicitation
+    void send_advert(const ether_addr &dhwaddr, const address &daddr);
 
     void send_solicit();
 

--- a/src/solicitor.cc
+++ b/src/solicitor.cc
@@ -1,0 +1,48 @@
+// ndppd - NDP Proxy Daemon
+// Copyright (C) 2011  Daniel Adolfsson <daniel@priv.nu>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// file author: Sergey E. Kolesnikov <rockingdemon@gmail.com>
+//
+#include <netinet/ether.h>
+#include "ndppd.h"
+#include "solicitor.h"
+NDPPD_NS_BEGIN
+
+logger& operator<<(logger& log, const solicitor& sol)
+{
+    char buff[18];
+    ether_ntoa_r(&sol._hwaddr, buff);
+    log
+            << "solicitor{addr=" << sol._addr.to_string()
+            << ", hwaddr=" << buff
+            << "}";
+    return log;
+}
+
+bool operator== (const ether_addr& a1, const ether_addr& a2)
+{
+    bool res = true;
+    for (int i=0; i<ETH_ALEN && res; i++) {
+        res = a1.ether_addr_octet[i] == a2.ether_addr_octet[i];
+    }
+    return res;
+}
+
+bool solicitor::is(const ndppd::address& addr, const ether_addr& hwaddr)
+{
+    return _addr==addr && _hwaddr==hwaddr;
+}
+NDPPD_NS_END

--- a/src/solicitor.h
+++ b/src/solicitor.h
@@ -1,0 +1,42 @@
+// ndppd - NDP Proxy Daemon
+// Copyright (C) 2011  Daniel Adolfsson <daniel@priv.nu>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// file author: Sergey E. Kolesnikov <rockingdemon@gmail.com>
+#pragma once
+
+#include "ndppd.h"
+#include <netinet/ether.h>
+#include <netinet/if_ether.h>
+
+NDPPD_NS_BEGIN
+class solicitor;
+logger& operator<<(logger& log, const solicitor& sol);
+
+class solicitor {
+public:
+    solicitor(const address& addr, const ether_addr& hwaddr)
+        : _addr(addr), _hwaddr(hwaddr) { }
+
+    const ether_addr& hwaddr() {return _hwaddr;}
+    const address& addr() {return _addr;}
+    bool is(const address& addr, const ether_addr& hwaddr);
+private:
+    friend logger& operator<<(logger& log, const solicitor& sol);
+    const address _addr;
+    const ether_addr _hwaddr;
+};
+
+NDPPD_NS_END


### PR DESCRIPTION
fixes most problems related to NA sending back to original solicitor.

It seems kernel doesn't allow us to send NA's not related to interface's ip6 addresses using IPPROTO_ICMPV6 api.
Had to reimplement on lower level and it works.